### PR TITLE
feature(tracelistener): log trace info only if trace must be considered

### DIFF
--- a/tracelistener/tracelistener.go
+++ b/tracelistener/tracelistener.go
@@ -130,6 +130,12 @@ func (tr *TraceWatcher) Watch() {
 				tr.ErrorChan <- fmt.Errorf("failed parsing operation, %w, data: %s", err, line.Text)
 				continue
 			}
+
+			tr.Logger.Infow("trace processed",
+				"kind", to.Operation,
+				"block_height", to.BlockHeight,
+				"tx_hash", to.TxHash,
+			)
 		}
 	}
 }


### PR DESCRIPTION
Spit out an INFO line with:
 - trace kind
 - block height
 - transaction hash
 
only when a trace has passed the "shall I consider this trace" test.