### PR TITLE
Properly split len prefixed delegation key

### DIFF
--- a/tracelistener/keys.go
+++ b/tracelistener/keys.go
@@ -18,21 +18,21 @@ import (
 //
 // Note: Address len 0 does not make sense, but since in the SDK it's "possible" to
 // have 0 len address for delegator/validator, we also consider empty address valid.
-func SplitDelegationKey(key []byte) (byte, string, string, error) {
+func SplitDelegationKey(key []byte) (string, string, error) {
 	// At-least: 3 bytes   -> 1, 2, 4 must be present. 1 byte each.
 	// At-max  : 513 bytes -> 3 bytes from (1, 2, 4) + 510 bytes from (3, 5).
 	if len(key) < 3 || len(key) > (1+1+255+1+255) {
-		return 0, "", "", fmt.Errorf("malformed key: length %d not in range", len(key))
+		return "", "", fmt.Errorf("malformed key: length %d not in range", len(key))
 	}
-	prefix, addresses := key[0], key[1:]                 // Strip the prefix byte.
+	_, addresses := key[0], key[1:]                      // Strip the prefix byte.
 	delAddrLen, addresses := addresses[0], addresses[1:] // Strip the delegator length byte.
 	if delAddrLen > 255 {
-		return 0, "", "", fmt.Errorf("malformed key: delegator address length out of range %d", delAddrLen)
+		return "", "", fmt.Errorf("malformed key: delegator address length out of range %d", delAddrLen)
 	}
 
 	// Check if we have enough bytes for the address of delegator + at least 1 byte for validator address length
 	if len(addresses) < int(delAddrLen)+1 {
-		return 0, "", "", fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"malformed key: delegator key length not sufficient. want atlease: %d got: %d",
 			delAddrLen+1,
 			len(addresses),
@@ -43,16 +43,16 @@ func SplitDelegationKey(key []byte) (byte, string, string, error) {
 	addresses = addresses[delAddrLen:]                   // Strip the delegator address.
 	valAddrLen, addresses := addresses[0], addresses[1:] // Strip the address length byte.
 	if valAddrLen > 255 {
-		return 0, "", "", fmt.Errorf("malformed key: validator address length out of range %d", valAddrLen)
+		return "", "", fmt.Errorf("malformed key: validator address length out of range %d", valAddrLen)
 	}
 	// Check if we have exact number of bytes for the address of validator.
 	if len(addresses) != int(valAddrLen) {
-		return 0, "", "", fmt.Errorf(
-			"malformed key: validator. want: %d got: %d",
+		return "", "", fmt.Errorf(
+			"malformed key: validator address length out of range. want: %d got: %d",
 			valAddrLen,
 			len(addresses),
 		)
 	}
 	valAddr := hex.EncodeToString(addresses)
-	return prefix, delAddr, valAddr, nil
+	return delAddr, valAddr, nil
 }

--- a/tracelistener/keys_test.go
+++ b/tracelistener/keys_test.go
@@ -58,7 +58,7 @@ func TestValidKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, da, va, err := SplitDelegationKey(tt.key)
+			da, va, err := SplitDelegationKey(tt.key)
 			require.NoError(t, err)
 			require.Equal(t, da, tt.wantDelAddr)
 			require.Equal(t, va, tt.wantValAddr)
@@ -87,19 +87,19 @@ func TestInValidKeys(t *testing.T) {
 		{
 			name:   "wrong len prefix - less found",
 			key:    []byte{1, 5, 3, 45, 21, 34, 90, 6, 0, 42, 5, 51, 6},
-			errMsg: "malformed key: validator. want: 6 got: 5",
+			errMsg: "malformed key: validator address length out of range. want: 6 got: 5",
 		},
 		{
 			name:   "wrong len prefix - more found",
 			key:    []byte{1, 5, 3, 45, 21, 34, 90, 4, 0, 42, 5, 51, 6},
-			errMsg: "malformed key: validator. want: 4 got: 5",
+			errMsg: "malformed key: validator address length out of range. want: 4 got: 5",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, _, err := SplitDelegationKey(tt.key)
+			_, _, err := SplitDelegationKey(tt.key)
 			require.Error(t, err)
 			require.ErrorContains(t, err, tt.errMsg)
 		})


### PR DESCRIPTION
Closes the double value showing after re delegation: https://github.com/allinbits/demeris-backend/issues/366

This PR **does not** deal with https://app.zenhub.com/workspaces/emeris-back-end-619cd009cc778000112d6259/issues/allinbits/demeris-backend/235. But the solution is very closely related. When we fix 235, we will use the `prefix` that we extract from the delegation key. Right now we just ignore the `prefix`.