### PR TITLE
ci: fix golang-ci lint after major upgrade

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
       - name: Configure git for private modules
         env:
           GIT_TOKEN: ${{ secrets.TENDERBOT_GIT_TOKEN }}


### PR DESCRIPTION
v3 of golang-ci lint action now explicitly requires a setup-go step before running.

See breaking changes: https://github.com/golangci/golangci-lint-action#compatibility
