### PR TITLE
fix: add EnableCpuProfiling env variable instead of using Debug

### DIFF
--- a/cmd/tracelistener/main.go
+++ b/cmd/tracelistener/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	logger := buildLogger(cfg)
 
-	if cfg.Debug {
+	if cfg.EnableCpuProfiling {
 		logger.Debugw("enabling cpu profiling")
 		defer profile.Start(profile.ProfilePath(".")).Stop()
 	}

--- a/tracelistener/config/config.go
+++ b/tracelistener/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	LogPath               string
 	Debug                 bool
 	JSONLogs              bool
+	EnableCpuProfiling    bool
 
 	// Processors configs
 	Processor ProcessorConfig


### PR DESCRIPTION
This was causing issues on staging environment where we want debug logs
but we don't want cpu profiling because it impacts performances and we
also don't have access to create a profile files.