### PR TITLE
fix(processor): add chain name constraint on unbonding delegations, delegations delete statements

### DIFF
--- a/tracelistener/processor/database.go
+++ b/tracelistener/processor/database.go
@@ -199,6 +199,8 @@ WHERE
 	delegator_address=:delegator_address
 AND
 	validator_address=:validator_address
+AND
+	chain_name=:chain_name
 `
 
 	// Account unbonding delegations-related queries
@@ -230,6 +232,8 @@ WHERE
 	delegator_address=:delegator_address
 AND
 	validator_address=:validator_address
+AND
+	chain_name=:chain_name
 `
 
 	// Denom traces-related queries


### PR DESCRIPTION
Pretty much what the title says.

Since `DELETE` statements will use the full table key for unbonding delegations and delegations, they should not block the database anymore hence lowering overall tracelistener memory usage in high-traffic situations (chain sync, Osmosis).

It also fixes a bug where two delegations from the same address to the same validator would be wrongly deleted.