### PR TITLE
ci: avoid running tests twice in pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
 
 env:


### PR DESCRIPTION
Pull requests already happen after a push, so tests are run twice right now.