### PR TITLE
ci(mergify): remove invalid draft condition

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,6 @@
 pull_request_rules:
   - name: automatic merge for main when CI passes and 2 reviews
     conditions:
-      - draft=false
       - "#approved-reviews-by>=2"
       - check-success=lint (v42)
       - check-success=code_cov (v42)


### PR DESCRIPTION
Booleans cannot be checked with =false, I don't know the correct way to express this. I just found out that there is a dashboard with a linter (https://dashboard.mergify.com/github/EmerisHQ/repo/tracelistener/config-editor?repositoryName=tracelistener&pullRequestNumber=83) but I can't get it to work so I just removed that conditions (*I think* draft PRs cannot be merged anyway)