### PR TITLE
ci: fix release action to use correct token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
           release_branch: main
           tag_format: "v%major%.%minor%.0"
         env:
-          GITHUB_TOKEN: ${{ secrets.TENDERBOT_GIT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey @akhilkumarpilli, Helder explained to me that we should use `GITHUB_TOKEN` which is a token generated automatically by GitHub for the workflow and grants some permissions on the current repo; instead of using `TENDERBOT_GIT_TOKEN` which basically is an account that have _some_ permissions on all the EmerisHQ repo (we use it to be able to download all the go dependencies).