### PR TITLE
ci: run docker-build action on new releases

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,13 +1,12 @@
 name: Build and push Docker images
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [Tests]
-    branches: [main]
-    types: [completed]
   push:
     tags:
       - 'v*'
+  release:
+    types:
+      - released
 
 jobs:
   setup-matrix:


### PR DESCRIPTION
It should now run automatically when we merge new changes and the github action creates a new release.