### PR TITLE
perf: add index on denom_traces.path

### DIFF
--- a/tracelistener/processor/ibc_denom_traces.go
+++ b/tracelistener/processor/ibc_denom_traces.go
@@ -21,7 +21,7 @@ type ibcDenomTracesProcessor struct {
 }
 
 var (
-	denomTracePathIndex = `CREATE INDEX ON ` + denomTracesTable.Name() + `(path)`
+	denomTracePathIndex = `CREATE INDEX IF NOT EXISTS denom_traces_path_idx ON ` + denomTracesTable.Name() + `(path)`
 )
 
 func (*ibcDenomTracesProcessor) Migrations() []string {


### PR DESCRIPTION
Considering the query `select count(1) from tracelistener.denom_traces
where path like 'transfer/%'` on staging:

- without index, it takes ~2.5s
- with index, it takes ~2ms after some time (the performance improvement
  is not instant, probably some part of the index creation is
  asynchronous with cockroachdb)