### PR TITLE
ci: ensure docker-build is triggered after release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,6 @@
 name: Build and push Docker images
 on:
+  workflow_call: # must be enabled when called from an other workflow
   workflow_dispatch:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   pull_request:
     types: [closed]
+    branches: [main]
 
   workflow_dispatch:
 
@@ -21,3 +22,9 @@ jobs:
           tag_format: "v%major%.%minor%.%patch%"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Manually trigger the docker build 
+  # (workflow can't trigger other workflows)
+  docker-build:
+    needs: [release]
+    uses: ./.github/workflows/docker-build.yml


### PR DESCRIPTION
A workflow can't trigger an other workflow, this is a gh action rule to
avoid infinite loop.

In order to trigger docker-build after release action, we have to do it
manually. Hopefully, it's possible to refer local actions.