### PR TITLE
perf(db): remove cockroach transactions

### DIFF
--- a/tracelistener/database/database.go
+++ b/tracelistener/database/database.go
@@ -34,7 +34,8 @@ func (i *Instance) Add(query string, data []interface{}, sleepFunc func()) error
 	if sleepFunc != nil {
 		sleepFunc()
 	}
-	return i.Instance.Exec(query, data, nil)
+	_, err := i.Instance.DB.NamedExec(query, data)
+	return err
 }
 
 // Jitter takes a duration <param: delta> and a dividing factor <param: factor>


### PR DESCRIPTION
Using transactions during flush brings no benefit and just introduces an
additional delay to the query execution.

This delay has been roughly mesured with 500.000 inserts :
WITH TX : 4.457864967s
W/O TX  : 2.44812082s

The change also removes the error when no rows are affected with the result, I think we're fine w/o that.